### PR TITLE
fix: release-please config and compat workflow gates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,10 +4,7 @@
     ".": {
       "release-type": "simple",
       "extra-files": [
-        {
-          "type": "generic",
-          "path": "onju-voice.yaml"
-        }
+        "onju-voice.yaml"
       ],
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false


### PR DESCRIPTION
## Summary
- Fix release-please extra-files config: use string format with x-release-please-version annotation instead of generic type (which failed parsing min_version)
- Fix compat workflow: gate handle-stable-result on new_version check to avoid spurious failures

## Test plan
- [ ] CI passes
- [ ] After merge, release-please creates Release PR correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)